### PR TITLE
include the port in the URL

### DIFF
--- a/GooglePyNotify.py
+++ b/GooglePyNotify.py
@@ -82,7 +82,7 @@ class HttpServer(SimpleHTTPRequestHandler):
         castdevice = next(cc for cc in CHROMECASTS if cc.device.model_name == "Google Home")
         castdevice.wait()
         mediacontroller = castdevice.media_controller # ChromeCast Specific
-        url = "http://" + ip_add + "/" + mp3
+        url = "http://" + ip_add + ":" + HOST_PORT + "/" + mp3
         print (url)
         mediacontroller.play_media(url, 'audio/mp3')
         return


### PR DESCRIPTION
I use this on 8080. Code needed this to fully support the `HOST_PORT` constant.